### PR TITLE
Refactor: Kakao login to use OIDC ID token

### DIFF
--- a/src/main/java/backend/mydays/controller/AuthController.java
+++ b/src/main/java/backend/mydays/controller/AuthController.java
@@ -36,10 +36,10 @@ public class AuthController {
         return BaseResponse.ok("로그인에 성공했습니다.", response);
     }
 
-    @Operation(summary = "카카오 로그인", description = "카카오 액세스 토큰으로 로그인하고 JWT 토큰을 발급받습니다. 신규 유저 여부를 함께 반환합니다.")
-    @PostMapping("/kakao/verify")
+    @Operation(summary = "카카오 로그인", description = "카카오 OIDC ID 토큰으로 로그인하고 JWT 토큰을 발급받습니다. 신규 유저 여부를 함께 반환합니다.")
+    @PostMapping("/kakao/oidc")
     public ResponseEntity<BaseResponse<KakaoLoginResponse>> kakaoLogin(@RequestBody KakaoLoginRequest request) {
-        KakaoLoginResponse response = authService.kakaoLogin(request.getAccessToken());
+        KakaoLoginResponse response = authService.kakaoLogin(request.getIdToken());
         return BaseResponse.ok("로그인에 성공했습니다.", response);
     }
 

--- a/src/main/java/backend/mydays/dto/auth/KakaoLoginRequest.java
+++ b/src/main/java/backend/mydays/dto/auth/KakaoLoginRequest.java
@@ -7,6 +7,5 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class KakaoLoginRequest {
-    private String accessToken;
-    private String refreshToken; // This will be ignored by the backend
+    private String idToken;
 }

--- a/src/main/java/backend/mydays/service/AuthService.java
+++ b/src/main/java/backend/mydays/service/AuthService.java
@@ -87,8 +87,8 @@ public class AuthService {
     }
 
     @Transactional
-    public KakaoLoginResponse kakaoLogin(String kakaoAccessToken) {
-        KakaoUserInfoResponse userInfoResponse = kakaoService.getKakaoUserInfo(kakaoAccessToken);
+    public KakaoLoginResponse kakaoLogin(String idToken) {
+        KakaoUserInfoResponse userInfoResponse = kakaoService.getKakaoUserInfo(idToken);
 
         String email = userInfoResponse.getKakaoAccount().getEmail();
         String nickname = userInfoResponse.getKakaoAccount().getProfile().getNickname();


### PR DESCRIPTION
- Modified the Kakao login flow to use the OIDC ID token instead of the access token.
- The backend now directly validates the ID token received from the client.
- This aligns with the recommended authentication flow and removes an unnecessary API call to fetch user info.